### PR TITLE
Adds a Dockerfile and updates README for steps to use Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.22.0-alpine3.19 AS builder
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup -u 1001
+
+WORKDIR /
+COPY go.mod ./
+COPY go.sum ./
+COPY *.go ./
+
+RUN go mod download
+RUN go build -o ./app
+
+FROM scratch
+LABEL authors="paihu"
+
+COPY --from=builder /etc/passwd /etc/passwd
+USER 1001
+
+COPY --from=builder /app /app
+
+EXPOSE 2055/udp
+EXPOSE 9191/tcp
+
+ENTRYPOINT [ "/app" ]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,42 @@
-# Prometheus netflow Exporter
-This is an exporter that exposes information gathered from netflow for use by the Prometheus monitoring system.
+# Prometheus Netflow Exporter
+This is an exporter that exposes information gathered from Netflow for use by the [Prometheus monitoring system](https://prometheus.io/).
 
-now support netflow v5 and v9.
+Supports Netflow `v5` and `v9`.
 
-## Installation
+## Installation and Usage
+Choose between running as a standalone binary or as a [Docker](https://www.docker.com/) container.
+
+### Go Binary
+Build:
+```shell
 go get -d
-
-go build
-
-## Usage
+go build -o netflow_exporter
 ```
+
+Run:
+```shell
 ./netflow_exporter
 ```
-Visit http://localhost:9191/metrics
 
-## note
-I think that netflow is not metric and analystic message.
+### Dockerfile
+Build:
+```shell
+docker build . -t netflow_exporter -f ./Dockerfile
+```
 
-Label conbination is too much to collect.
+Run:
+```shell
+docker container run -p 2055:2055/udp -p 9191:9191 netflow_exporter
+```
 
+Add application arguments to the end of the above command as if running the standalone binary to make use of them. For example, add `--telemetry-path=/foo`.
+
+If you would like to change the port for the Netflow listener or the metrics endpoint, change the port arguments for the above Docker command and add the `--netflow.listen-address` and/or the `--web.listen-address` arguments to the end of the above command to pass the arguments to `netflow_exporter`.
+
+## Usage
+Visit your Prometheus metrics endpoint: http://localhost:9191/metrics
+
+## Notes
+I think that netflow is not a metrics and analytics message.
+
+Label combination is too much to collect.


### PR DESCRIPTION
Adds a `Dockerfile` as well as steps in the README to get `netflow_exporter` running within a Docker container.